### PR TITLE
fixed error 200751 when registerConsumerCard parameter is not provided.

### DIFF
--- a/samples/subscription-samples/create_subscription_api.php
+++ b/samples/subscription-samples/create_subscription_api.php
@@ -13,6 +13,7 @@ $paymentCard->setCardNumber("4603450000000000");
 $paymentCard->setExpireMonth("12");
 $paymentCard->setExpireYear("2030");
 $paymentCard->setCvc("123");
+$paymentCard->setRegisterConsumerCard(1);
 $request->setPaymentCard($paymentCard);
 $customer = new \Iyzipay\Model\Customer();
 $customer->setName("John");


### PR DESCRIPTION
registerConsumerCard was missing in the creating subscription via api sample.