### PR TITLE
Create checkout form with subscription customer

### DIFF
--- a/src/Iyzipay/Model/Subscription/SubscriptionCustomer.php
+++ b/src/Iyzipay/Model/Subscription/SubscriptionCustomer.php
@@ -2,6 +2,7 @@
 
 namespace Iyzipay\Model\Subscription;
 
+use Iyzipay\JsonBuilder;
 use Iyzipay\Options;
 use Iyzipay\IyzipayResource;
 use Iyzipay\Model\Mapper\Subscription\SubscriptionCustomerMapper;
@@ -62,6 +63,7 @@ class SubscriptionCustomer extends IyzipayResource
     {
         return $this->referenceCode;
     }
+
     public function setCustomerStatus($customerStatus)
     {
         $this->customerStatus = $customerStatus;
@@ -131,6 +133,7 @@ class SubscriptionCustomer extends IyzipayResource
     {
         $this->createdDate = $createdDate;
     }
+
     public function getShippingContactName(){
 
         return $this->shippingContactName;
@@ -229,5 +232,37 @@ class SubscriptionCustomer extends IyzipayResource
     public function setBillingZipCode($billingZipCode){
 
         return $this->billingZipCode = $billingZipCode;
+    }
+
+    public function getJsonObject($locale = null,$conversationId = null,$customerReferenceCode = null)
+    {
+        return JsonBuilder::create()
+            ->add("locale", $locale)
+            ->add("conversationId", $conversationId)
+            ->add("customerReferenceCode", $customerReferenceCode)
+            ->add("name", $this->getName())
+            ->add("surname", $this->getSurname())
+            ->add("identityNumber", $this->getIdentityNumber())
+            ->add("email", $this->getEmail())
+            ->add("gsmNumber", $this->getGsmNumber())
+            ->add("billingAddress",
+                JsonBuilder::create()
+                    ->add("contactName", $this->getBillingContactName())
+                    ->add("city", $this->getBillingCity())
+                    ->add("country", $this->getBillingCountry())
+                    ->add("address", $this->getBillingAddress())
+                    ->add("zipCode", $this->getBillingZipCode())
+                    ->getObject()
+            )
+            ->add("shippingAddress",
+                JsonBuilder::create()
+                    ->add("contactName", $this->getShippingContactName())
+                    ->add("city", $this->getShippingCity())
+                    ->add("country", $this->getShippingCountry())
+                    ->add("address", $this->getShippingAddress())
+                    ->add("zipCode", $this->getShippingZipCode())
+                    ->getObject()
+            )
+            ->getObject();
     }
 }

--- a/src/Iyzipay/Request/Subscription/SubscriptionCreateCheckoutFormWithSubscriptionCustomerRequest.php
+++ b/src/Iyzipay/Request/Subscription/SubscriptionCreateCheckoutFormWithSubscriptionCustomerRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Iyzipay\Request\Subscription;
+
+use Iyzipay\JsonBuilder;
+use Iyzipay\Model\Subscription\SubscriptionCustomer;
+use Iyzipay\Request;
+
+class SubscriptionCreateCheckoutFormWithSubscriptionCustomerRequest extends Request
+{
+
+    private $pricingPlanReferenceCode;
+    private $callbackUrl;
+    private $subscriptionInitialStatus;
+    private $customer;
+
+    public function __construct()
+    {
+        $this->customer = new SubscriptionCustomer();
+    }
+
+    public function getCustomer()
+    {
+        return $this->customer;
+    }
+
+    public function setCustomer(SubscriptionCustomer $customer)
+    {
+        $this->customer = $customer;
+    }
+
+    public function getCallbackUrl()
+    {
+        return $this->callbackUrl;
+    }
+
+    public function setCallbackUrl($callbackUrl)
+    {
+        $this->callbackUrl = $callbackUrl;
+    }
+    public function getPricingPlanReferenceCode()
+    {
+        return $this->pricingPlanReferenceCode;
+    }
+
+    public function setPricingPlanReferenceCode($pricingPlanReferenceCode)
+    {
+        $this->pricingPlanReferenceCode = $pricingPlanReferenceCode;
+    }
+
+    public function getSubscriptionInitialStatus()
+    {
+        return $this->subscriptionInitialStatus;
+    }
+
+    public function setSubscriptionInitialStatus($subscriptionInitialStatus)
+    {
+        $this->subscriptionInitialStatus = $subscriptionInitialStatus;
+    }
+
+    public function getJsonObject()
+    {
+        return JsonBuilder::fromJsonObject(parent::getJsonObject())
+            ->add("locale", $this->getLocale())
+            ->add("conversationId", $this->getConversationId())
+            ->add("callbackUrl", $this->getCallbackUrl())
+            ->add("pricingPlanReferenceCode", $this->getPricingPlanReferenceCode())
+            ->add("subscriptionInitialStatus", $this->getSubscriptionInitialStatus())
+            ->add("customer",
+                $this->getCustomer()->getJsonObject($locale = null,$conversationId= null, $customerReferenceCode = null)
+            )
+            ->getObject();
+    }
+}

--- a/tests/Iyzipay/Tests/Request/Subscription/SubscriptionCreateCheckoutFormWithSubscriptionCustomerRequestTest.php
+++ b/tests/Iyzipay/Tests/Request/Subscription/SubscriptionCreateCheckoutFormWithSubscriptionCustomerRequestTest.php
@@ -1,0 +1,103 @@
+<?php
+
+
+namespace Iyzipay\Tests\Request\Subscription;
+
+use Iyzipay\Model\Subscription\SubscriptionCustomer;
+use Iyzipay\Request\Subscription\SubscriptionCreateCheckoutFormWithSubscriptionCustomerRequest;
+use Iyzipay\Tests\TestCase;
+use Iyzipay\Model\Locale;
+
+class SubscriptionCreateCheckoutFormWithSubscriptionCustomerRequestTest extends TestCase
+{
+    public function test_should_get_json_object()
+    {
+        $request = $this->prepareRequest();
+        $jsonObject = $request->getJsonObject();
+        $this->assertEquals(Locale::TR, $jsonObject["locale"]);
+        $this->assertEquals("123456789", $jsonObject["conversationId"]);
+        $this->assertEquals("http://callbackurl.com", $jsonObject["callbackUrl"]);
+        $this->assertEquals("ffed3cb1-1cf6-476f-9a0c-ae2a89e2cc1d", $jsonObject["pricingPlanReferenceCode"]);
+        $this->assertEquals("ACTIVE", $jsonObject["subscriptionInitialStatus"]);
+        $this->assertEquals("John", $jsonObject["customer"]["name"]);;
+        $this->assertEquals("Doe", $jsonObject["customer"]["surname"]);
+        $this->assertEquals("+905555555555", $jsonObject["customer"]["gsmNumber"]);
+        $this->assertEquals("johndoe@iyzico.com", $jsonObject["customer"]["email"]);
+        $this->assertEquals("11111111111", $jsonObject["customer"]["identityNumber"]);
+        $this->assertEquals("John Doe", $jsonObject["customer"]["shippingAddress"]["contactName"]);
+        $this->assertEquals("Istanbul", $jsonObject["customer"]["shippingAddress"]["city"]);
+        $this->assertEquals("Turkey", $jsonObject["customer"]["shippingAddress"]["country"]);
+        $this->assertEquals("Uskudar Burhaniye Mahallesi iyzico A.S", $jsonObject["customer"]["shippingAddress"]["address"]);
+        $this->assertEquals("34660", $jsonObject["customer"]["shippingAddress"]["zipCode"]);
+        $this->assertEquals("John Doe", $jsonObject["customer"]["billingAddress"]["contactName"]);
+        $this->assertEquals("Istanbul", $jsonObject["customer"]["billingAddress"]["city"]);
+        $this->assertEquals("Turkey", $jsonObject["customer"]["billingAddress"]["country"]);
+        $this->assertEquals("Uskudar Burhaniye Mahallesi iyzico A.S", $jsonObject["customer"]["billingAddress"]["address"]);
+        $this->assertEquals("34660", $jsonObject["customer"]["billingAddress"]["zipCode"]);
+
+    }
+
+    public function test_should_get_json_string()
+    {
+        $request = $this->prepareRequest();
+        $json = '{
+                  "callbackUrl": "http://callbackurl.com",
+                  "conversationId": "123456789",
+                  "customer": {
+                    "billingAddress": {
+                      "address": "Uskudar Burhaniye Mahallesi iyzico A.S",
+                      "city": "Istanbul",
+                      "contactName": "John Doe",
+                      "country": "Turkey",
+                      "zipCode": "34660"
+                    },
+                    "email": "johndoe@iyzico.com",
+                    "gsmNumber": "+905555555555",
+                    "identityNumber": "11111111111",
+                    "name": "John",
+                    "shippingAddress": {
+                      "address": "Uskudar Burhaniye Mahallesi iyzico A.S",
+                      "city": "Istanbul",
+                      "contactName": "John Doe",
+                      "country": "Turkey",
+                      "zipCode": "34660"
+                    },
+                    "surname": "Doe"
+                  },
+                  "locale": "tr",
+                  "pricingPlanReferenceCode": "ffed3cb1-1cf6-476f-9a0c-ae2a89e2cc1d",
+                  "subscriptionInitialStatus": "ACTIVE"
+                }';
+
+        $this->assertJson($request->toJsonString());
+        $this->assertJsonStringEqualsJsonString($json, $request->toJsonString());
+    }
+
+    private function prepareRequest()
+    {
+        $request = new SubscriptionCreateCheckoutFormWithSubscriptionCustomerRequest();
+        $request->setConversationId("123456789");
+        $request->setLocale("tr");
+        $request->setPricingPlanReferenceCode("ffed3cb1-1cf6-476f-9a0c-ae2a89e2cc1d");
+        $request->setSubscriptionInitialStatus("ACTIVE");
+        $request->setCallbackUrl("http://callbackurl.com");
+        $customer = new SubscriptionCustomer();
+        $customer->setName("John");
+        $customer->setSurname("Doe");
+        $customer->setGsmNumber("+905555555555");
+        $customer->setEmail("johndoe@iyzico.com");
+        $customer->setIdentityNumber("11111111111");
+        $customer->setShippingContactName("John Doe");
+        $customer->setShippingCity("Istanbul");
+        $customer->setShippingCountry("Turkey");
+        $customer->setShippingAddress("Uskudar Burhaniye Mahallesi iyzico A.S");
+        $customer->setShippingZipCode("34660");
+        $customer->setBillingContactName("John Doe");
+        $customer->setBillingCity("Istanbul");
+        $customer->setBillingCountry("Turkey");
+        $customer->setBillingAddress("Uskudar Burhaniye Mahallesi iyzico A.S");
+        $customer->setBillingZipCode("34660");
+        $request->setCustomer($customer);
+        return $request;
+    }
+}


### PR DESCRIPTION
This PR allows you to create a checkout form with existing subscription customers. 

Why we need this?

If we already create any subscription customer before checkout we can use this model creating new checkout form.