### PR TITLE
fix-php84-nullable-parameter-deprecations

### DIFF
--- a/src/Iyzipay/IyziAuthV2Generator.php
+++ b/src/Iyzipay/IyziAuthV2Generator.php
@@ -4,13 +4,13 @@ namespace Iyzipay;
 
 class IyziAuthV2Generator
 {
-    public static function generateAuthContent($uri, $apiKey, $secretKey, $randomString, Request $request = null)
+    public static function generateAuthContent($uri, $apiKey, $secretKey, $randomString, ?Request $request = null)
     {
         $hashStr = "apiKey:" . $apiKey . "&randomKey:" . $randomString ."&signature:" . self::getHmacSHA256Signature($uri, $secretKey, $randomString, $request);
         return base64_encode($hashStr);
     }
 
-    public static function getHmacSHA256Signature($uri, $secretKey, $randomString, Request $request = null)
+    public static function getHmacSHA256Signature($uri, $secretKey, $randomString, ?Request $request = null)
     {
         $dataToEncrypt = $randomString . self::getPayload($uri, $request);
 
@@ -18,7 +18,7 @@ class IyziAuthV2Generator
         return bin2hex($hash);
     }
 
-    public static function getPayload($uri, Request $request = null)
+    public static function getPayload($uri, ?Request $request = null)
     {
         $uriPath = $uri;
         $startsWithV2 = strpos($uri, '.com/v2');

--- a/src/Iyzipay/IyzipayResource.php
+++ b/src/Iyzipay/IyzipayResource.php
@@ -12,7 +12,7 @@ class IyzipayResource extends ApiResource {
     private $conversationId;
 
 
-    protected static function getHttpHeadersV2($uri, Request $request = null, Options $options) {
+    protected static function getHttpHeadersV2($uri, ?Request $request, Options $options) {
         $header = array(
             "Accept: application/json",
             "Content-type: application/json",
@@ -25,7 +25,7 @@ class IyzipayResource extends ApiResource {
         return $header;
     }
 
-    protected static function prepareAuthorizationStringV2($uri, Request $request = null, Options $options, $rnd) {
+    protected static function prepareAuthorizationStringV2($uri, ?Request $request, Options $options, $rnd) {
         $hash = IyziAuthV2Generator::generateAuthContent($uri, $options->getApiKey(), $options->getSecretKey(), $rnd, $request);
 
         return 'IYZWSv2' . ' ' . $hash;

--- a/src/Iyzipay/JsonBuilder.php
+++ b/src/Iyzipay/JsonBuilder.php
@@ -56,7 +56,7 @@ class JsonBuilder
      * @param array $array
      * @return JsonBuilder
      */
-    public function addArray($key, array $array = null)
+    public function addArray($key, ?array $array = null)
     {
         if (isset($array)) {
             foreach ($array as $index => $value) {

--- a/src/Iyzipay/RequestStringBuilder.php
+++ b/src/Iyzipay/RequestStringBuilder.php
@@ -68,7 +68,7 @@ class RequestStringBuilder
      * @param array $array
      * @return RequestStringBuilder
      */
-    public function appendArray($key, array $array = null)
+    public function appendArray($key, ?array $array = null)
     {
         if (isset($array)) {
             $appendedValue = "";


### PR DESCRIPTION
* Use explicit nullable types (?Request, ?array) to fix PHP 8.4 deprecations.
* Fix optional-before-required parameter order in IyzipayResource V2 auth/header methods.
* Preserve PHP 7.4 compatibility without behavioral changes.